### PR TITLE
Prefill toilet form when creating from a suggested toilet

### DIFF
--- a/Toilets4LondonAPI/toilets4london/admin.py
+++ b/Toilets4LondonAPI/toilets4london/admin.py
@@ -11,6 +11,9 @@ from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 import Toilets4LondonAPI.settings as settings
 
+# Default owner for toilets created from an app suggestion
+SUGGESTION_OWNER_EMAIL = "nina@toilets4london.com"
+
 
 class ToiletResource(resources.ModelResource):
     class Meta:
@@ -108,7 +111,6 @@ class ToiletAdmin(ImportExportModelAdmin):
         else:
             if "owner" in form.base_fields:
                 form.base_fields["owner"].initial = request.user
-                form.base_fields["owner"].disabled = True
         if not request.user.is_superuser:  # Don't let non super users change these
             if "covid" in form.base_fields:
                 form.base_fields["covid"].disabled = True
@@ -118,6 +120,20 @@ class ToiletAdmin(ImportExportModelAdmin):
                 form.base_fields["num_ratings"].disabled = True
             if "owner" in form.base_fields:
                 form.base_fields["owner"].disabled = True
+        if "latitude" in request.GET and "longitude" in request.GET:
+            form.base_fields["latitude"].initial = request.GET["latitude"]
+            form.base_fields["longitude"].initial = request.GET["longitude"]
+        if obj is None and request.GET.get("from_suggestion") == "1":
+            if "name" in form.base_fields:
+                form.base_fields["name"].initial = request.GET.get("details", "")
+            if "data_source" in form.base_fields:
+                form.base_fields["data_source"].initial = "App upload"
+            if "owner" in form.base_fields:
+                suggestion_owner = Toilets4LondonUser.objects.filter(
+                    email=SUGGESTION_OWNER_EMAIL
+                ).first()
+                if suggestion_owner is not None:
+                    form.base_fields["owner"].initial = suggestion_owner
         return form
 
     def has_change_permission(self, request, obj=None):
@@ -156,14 +172,10 @@ class ToiletAdmin(ImportExportModelAdmin):
                     settings.MAPS_KEY
                 ),
                 "js/admin/location_picker.js",
+                "js/admin/prefill_from_suggestion.js",
             )
-
-    def get_form(self, request, obj=None, **kwargs):
-        form = super().get_form(request, obj, **kwargs)
-        if "latitude" in request.GET and "longitude" in request.GET:
-            form.base_fields["latitude"].initial = request.GET["latitude"]
-            form.base_fields["longitude"].initial = request.GET["longitude"]
-        return form
+        else:
+            js = ("js/admin/prefill_from_suggestion.js",)
 
 
 @admin.register(SuggestedToilet)

--- a/Toilets4LondonAPI/toilets4london/tests/admin_prefill_tests.py
+++ b/Toilets4LondonAPI/toilets4london/tests/admin_prefill_tests.py
@@ -1,0 +1,71 @@
+from django.test import TestCase, Client, override_settings
+from Toilets4LondonAPI.toilets4london.admin import SUGGESTION_OWNER_EMAIL
+from Toilets4LondonAPI.toilets4london.models import Toilets4LondonUser
+
+
+@override_settings(
+    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage"
+)
+class SuggestionPrefillTests(TestCase):
+
+    def setUp(self):
+        self.superuser = Toilets4LondonUser.objects.create_superuser(
+            email="admin@example.com", password="pass12345"
+        )
+        self.nina = Toilets4LondonUser.objects.create_user(
+            email=SUGGESTION_OWNER_EMAIL, password="pass12345"
+        )
+        self.client = Client()
+        self.client.force_login(self.superuser)
+
+    def get_add_form(self, params=None):
+        response = self.client.get("/admin/toilets4london/toilet/add/", params or {})
+        self.assertEqual(response.status_code, 200)
+        return response.context["adminform"].form
+
+    def get_initial(self, form, field_name):
+        return form.get_initial_for_field(form.fields[field_name], field_name)
+
+    def test_prefill_from_suggestion(self):
+        form = self.get_add_form(
+            {
+                "from_suggestion": "1",
+                "latitude": "51.5074",
+                "longitude": "-0.1278",
+                "details": "Toilet in the nice cafe",
+            }
+        )
+        self.assertEqual(self.get_initial(form, "latitude"), "51.5074")
+        self.assertEqual(self.get_initial(form, "longitude"), "-0.1278")
+        self.assertEqual(self.get_initial(form, "name"), "Toilet in the nice cafe")
+        self.assertEqual(self.get_initial(form, "data_source"), "App upload")
+        self.assertEqual(self.get_initial(form, "owner"), self.nina)
+
+    def test_prefill_from_suggestion_without_details(self):
+        form = self.get_add_form(
+            {
+                "from_suggestion": "1",
+                "latitude": "51.5074",
+                "longitude": "-0.1278",
+            }
+        )
+        self.assertEqual(self.get_initial(form, "name"), "")
+        self.assertEqual(self.get_initial(form, "data_source"), "App upload")
+
+    def test_prefill_owner_falls_back_when_suggestion_owner_missing(self):
+        self.nina.delete()
+        form = self.get_add_form(
+            {
+                "from_suggestion": "1",
+                "latitude": "51.5074",
+                "longitude": "-0.1278",
+                "details": "Some toilet",
+            }
+        )
+        self.assertEqual(self.get_initial(form, "owner"), self.superuser)
+
+    def test_normal_add_form_not_prefilled(self):
+        form = self.get_add_form()
+        self.assertEqual(self.get_initial(form, "name"), "")
+        self.assertNotEqual(self.get_initial(form, "data_source"), "App upload")
+        self.assertEqual(self.get_initial(form, "owner"), self.superuser)

--- a/static/js/admin/prefill_from_suggestion.js
+++ b/static/js/admin/prefill_from_suggestion.js
@@ -1,0 +1,71 @@
+/**
+ * When the toilet add form is opened from a suggested toilet
+ * (?from_suggestion=1&latitude=..&longitude=..), prefill the address
+ * (via Google reverse geocoding) and the borough (via postcodes.io).
+ * Both are left blank if the lookup fails.
+ */
+(function () {
+
+    var params = new URLSearchParams(window.location.search);
+
+    if (params.get('from_suggestion') !== '1') {
+        return;
+    }
+
+    var lat = parseFloat(params.get('latitude'));
+    var lng = parseFloat(params.get('longitude'));
+
+    if (isNaN(lat) || isNaN(lng)) {
+        return;
+    }
+
+    function prefillAddress() {
+        var addressInput = document.getElementById('id_address');
+        if (!addressInput || addressInput.value) {
+            return;
+        }
+        if (typeof google === 'undefined' || !google.maps) {
+            return;
+        }
+        var geocoder = new google.maps.Geocoder();
+        geocoder.geocode({location: {lat: lat, lng: lng}}, function (results, status) {
+            if (status === 'OK' && results[0] && !addressInput.value) {
+                addressInput.value = results[0].formatted_address
+                    .replace(/, London, UK$/, '')
+                    .replace(/, London$/, '')
+                    .replace(/, UK$/, '');
+            }
+        });
+    }
+
+    function prefillBorough() {
+        var boroughSelect = document.getElementById('id_borough');
+        if (!boroughSelect || boroughSelect.value) {
+            return;
+        }
+        fetch('https://api.postcodes.io/postcodes?lon=' + lng + '&lat=' + lat + '&limit=1')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.result && data.result.length > 0) {
+                    var district = data.result[0].admin_district;
+                    if (district && !boroughSelect.value) {
+                        for (var i = 0; i < boroughSelect.options.length; i++) {
+                            if (boroughSelect.options[i].value === district) {
+                                boroughSelect.value = district;
+                                return;
+                            }
+                        }
+                    }
+                }
+            })
+            .catch(function () {
+                // Leave borough blank if lookup fails
+            });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        prefillAddress();
+        prefillBorough();
+    });
+
+})();

--- a/templates/admin/toilets4london/suggestedtoilet/change_form.html
+++ b/templates/admin/toilets4london/suggestedtoilet/change_form.html
@@ -2,13 +2,17 @@
 
 {% block content %}
 {{ block.super }}
-<a href="#" id="create-toilet-button" class="button">Create Toilet with Prefilled Lat/Lng</a>
+<a href="#" id="create-toilet-button" class="button">Create Toilet from this Suggestion</a>
 <script type="text/javascript">
     document.getElementById('create-toilet-button').addEventListener('click', function(event) {
         event.preventDefault();
-        const latitude = "{{ original.latitude }}";
-        const longitude = "{{ original.longitude }}";
-        const url = `/admin/toilets4london/toilet/add/?latitude=${latitude}&longitude=${longitude}`;
+        const params = new URLSearchParams({
+            from_suggestion: '1',
+            latitude: "{{ original.latitude }}",
+            longitude: "{{ original.longitude }}",
+            details: "{{ original.details|escapejs }}",
+        });
+        const url = '/admin/toilets4london/toilet/add/?' + params.toString();
         window.open(url, '_blank');
     });
 </script>


### PR DESCRIPTION
## Summary

When creating a new toilet from a suggested toilet (the "Create Toilet from this Suggestion" button on the suggested toilet admin page), the toilet add form now prefills:

1. **Data source** — set to `App upload`
2. **Borough** — auto-detected from the lat/lng using postcodes.io (client-side, same approach as the review-suggestions page); left blank if detection fails
3. **Address** — reverse-geocoded from the lat/lng using the Google Maps geocoder, with `, London, UK` suffixes stripped; left blank if geocoding fails
4. **Name** — the text the user entered as the suggestion details
5. **Owner** — the user with email `nina@toilets4london.com` (falls back to the logged-in user if that account doesn't exist)

Latitude/longitude continue to be prefilled as before.

## How it works

- The suggestion admin page button now passes `from_suggestion=1` and the suggestion `details` (URL-encoded) alongside lat/lng.
- `ToiletAdmin.get_form` handles the server-side prefills (name, data source, owner) when `from_suggestion=1` is present.
- A new `static/js/admin/prefill_from_suggestion.js` (loaded on the toilet admin form) does the borough lookup and address reverse-geocode in the browser, only filling fields that are still empty.

## Also fixed

`ToiletAdmin` defined `get_form` twice, so the second definition (lat/lng prefill) was silently shadowing the first — the owner prefill and the non-superuser field-disabling logic for `covid`/`rating`/`num_ratings`/`owner` were never running. The two are now merged into one method. One deliberate deviation from the old (dead) code: on the add form the owner field is no longer disabled for superusers, so the prefilled owner can still be changed; it remains disabled for non-superusers.

## Tests

Added `admin_prefill_tests.py` covering the server-side prefills (with/without details, missing nina account fallback, and that a normal add form is unaffected). All 44 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)